### PR TITLE
chore(release-please): add personal access token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: GoogleCloudPlatform/release-please-action@v2
         with:
           # token: ${{ steps.get-token.outputs.token }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           release-type: node
           package-name: '@netlify/delta-action'


### PR DESCRIPTION
Until we make this work with the GitHub app, I've added a personal access token.

This is required for so the release PR can trigger other workflows.