### PR TITLE
chore: fix prepare-dist

### DIFF
--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - release-*
 jobs:
-  swagger-bump:
+  prepare-dist:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
       - uses: actions/setup-node@v2
         with:
           node-version: 15.x


### PR DESCRIPTION
See https://github.com/stefanzweifel/git-auto-commit-action#commits-of-this-action-do-not-trigger-new-workflow-runs