### PR TITLE
fix: use correct format in comment metadata

### DIFF
--- a/src/lib/comment.js
+++ b/src/lib/comment.js
@@ -3,7 +3,8 @@ const regexEscape = require('regex-escape')
 const { formatValue } = require('./units')
 
 const createComment = ({ baseSha, metrics, job, previousMetrics = {}, title }) => {
-  const metadata = `<!--delta:${job}@${JSON.stringify(metrics)}-->`
+  const metricValues = metrics.reduce((acc, { name, value }) => ({ ...acc, [name]: value }), {})
+  const metadata = `<!--delta:${job}@${JSON.stringify(metricValues)}-->`
   const metricsList = metrics.map((metric) => getMetricLine(metric, previousMetrics[metric.name])).join('\n')
   const baseShaLine = baseSha && previousMetrics.length !== 0 ? `Comparing with ${baseSha}\n\n` : ''
 


### PR DESCRIPTION
**Which problem is this pull request solving?**

This PR fixes a regression introduced with the last set of changes, where the comment metadata had the wrong format.

(Note to reviewer: I'm sorry that this is such a black box right now. I'll work on some tests as soon as I have some time.)

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**

🐷 