### PR TITLE
chore: run CI on latest Node.js

### DIFF
--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -17,7 +17,8 @@ jobs:
           token: ${{ steps.get-token.outputs.token }}
       - uses: actions/setup-node@v2
         with:
-          node-version: 15.x
+          node-version: '*'
+          check-latest: true
       - name: Install dependencies
         run: npm ci
       - name: Prepare dist

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [8.17.0, 15.x]
+        node-version: [8.17.0, '*']
         exclude:
           - os: macOS-latest
             node-version: 8.17.0
@@ -23,15 +23,16 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
-      - name: Node.js ${{ matrix.node-version }}
+      - name: Using Node.js
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: true
       - name: Install dependencies
         run: npm ci
       - name: Linting
         run: npm run format:ci
-        if: "${{ matrix.node-version == '15.x' }}"
+        if: "${{ matrix.node-version == '*' }}"
       - name: Tests
         run: npm run test:ci
       - name: Get test coverage flags
@@ -40,7 +41,7 @@ jobs:
           os=${{ matrix.os }}
           node=${{ matrix.node-version }}
           echo "::set-output name=os::${os/-latest/}"
-          echo "::set-output name=node::node_${node//./}"
+          echo "::set-output name=node::node_${node//[.*]/}"
         shell: bash
       - uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
Part of https://github.com/netlify/team-dev/issues/19

This runs the CI on the `latest` Node.js version.