### PR TITLE
feat: add historical data to metadata comments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,19 @@
 const core = require('@actions/core')
 const github = require('@actions/github')
 
-const { createComment, findDeltaComment, getMetricsComment } = require('./lib/comment')
+const {
+  createHeadBranchComment,
+  createPullRequestComment,
+  findDeltaComment,
+  getMetricsComment,
+} = require('./lib/comment')
 const { readDeltaFiles } = require('./lib/delta_file')
 const { getCommentsFromMainBranch } = require('./lib/github')
 const { getInputs } = require('./lib/inputs')
 
 const processHeadBranch = async ({ commitSha, headMetrics, job, octokit, owner, repo, title }) => {
-  const comment = createComment({ job, metrics: headMetrics, title })
+  const previousCommit = await getCommentsFromMainBranch({ commitIndex: 1, octokit, owner, repo })
+  const comment = createHeadBranchComment({ commitSha, job, metrics: headMetrics, previousCommit, title })
 
   await octokit.rest.repos.createCommitComment({
     owner,
@@ -23,7 +29,7 @@ const processPullRequest = async ({ headMetrics, job, octokit, owner, prNumber, 
 
   core.debug(`Base metrics: ${JSON.stringify(baseMetrics)}`)
 
-  const comment = createComment({
+  const comment = createPullRequestComment({
     baseSha,
     job,
     metrics: headMetrics,

--- a/src/lib/comment.js
+++ b/src/lib/comment.js
@@ -2,10 +2,28 @@ const regexEscape = require('regex-escape')
 
 const { formatValue } = require('./units')
 
-const createComment = ({ baseSha, metrics, job, previousMetrics = {}, title }) => {
-  const metricValues = metrics.reduce((acc, { name, value }) => ({ ...acc, [name]: value }), {})
-  const metadata = `<!--delta:${job}@${JSON.stringify(metricValues)}-->`
-  const metricsList = metrics.map((metric) => getMetricLine(metric, previousMetrics[metric.name])).join('\n')
+const PAST_METRICS_COUNT = 30
+
+const createHeadBranchComment = ({ commitSha, metrics, job, previousCommit, title }) => {
+  const allMetrics = getMetricsForHeadBranch({ commitSha, job, metrics, previousCommit })
+  const metadata = `<!--delta:${job}@${JSON.stringify(allMetrics)}-->`
+  const metricsList = metrics.map((metric) => getMetricLine(metric)).join('\n')
+
+  return `## ${title}\n\n${metricsList}\n${metadata}`
+}
+
+const createPullRequestComment = ({ baseSha, job, metrics, previousMetrics = {}, title }) => {
+  const metadata = `<!--delta:${job}@{}-->`
+  const metricsList = metrics
+    .map((metric) => {
+      // Accounting for both the legacy metadata format (object) and the new
+      // format (array of objects).
+      const comparison = Array.isArray(previousMetrics) ? previousMetrics[0] : previousMetrics
+      const previousValue = comparison[metric.name]
+
+      return getMetricLine(metric, previousValue)
+    })
+    .join('\n')
   const baseShaLine = baseSha && previousMetrics.length !== 0 ? `Comparing with ${baseSha}\n\n` : ''
 
   return `## ${title}\n\n${baseShaLine}${metricsList}\n${metadata}`
@@ -15,6 +33,23 @@ const getMetricsComment = ({ comments, job }) => {
   const deltaComment = comments.map(({ body }) => parseComment(body, job)).find(Boolean)
 
   return deltaComment
+}
+
+const getMetricsForHeadBranch = ({ commitSha, job, metrics, previousCommit }) => {
+  const metricValues = metrics.reduce((acc, { name, value }) => ({ ...acc, [name]: value }), {})
+  const currentCommitMetrics = { __commit: commitSha, ...metricValues }
+
+  if (previousCommit) {
+    const previousMetrics = getMetricsComment({ comments: previousCommit.comments, job })
+    const normalizedPreviousMetrics = normalizeMetrics(previousMetrics, previousCommit.baseSha).slice(
+      0,
+      PAST_METRICS_COUNT - 1,
+    )
+
+    return [currentCommitMetrics, ...normalizedPreviousMetrics]
+  }
+
+  return [currentCommitMetrics]
 }
 
 const getMetricLine = ({ displayName, name, units, value }, previousValue) => {
@@ -49,6 +84,14 @@ const findDeltaComment = (body, job) => {
   return match
 }
 
+const normalizeMetrics = (metrics, sha) => {
+  if (!metrics || Array.isArray(metrics)) {
+    return metrics
+  }
+
+  return [{ __commit: sha, ...metrics }]
+}
+
 const parseComment = (body, job) => {
   const match = findDeltaComment(body, job)
 
@@ -63,4 +106,4 @@ const parseComment = (body, job) => {
   }
 }
 
-module.exports = { createComment, findDeltaComment, getMetricsComment }
+module.exports = { createHeadBranchComment, createPullRequestComment, findDeltaComment, getMetricsComment }

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -6,12 +6,12 @@ const getBranchNameFromRef = (ref) => {
   }
 }
 
-const getCommentsFromMainBranch = async ({ octokit, owner, repo }) => {
+const getCommentsFromMainBranch = async ({ commitIndex = 0, octokit, owner, repo }) => {
   const { data: commits } = await octokit.rest.repos.listCommits({
     owner,
     repo,
   })
-  const baseSha = commits[0].sha
+  const baseSha = commits[commitIndex].sha
   const { data: comments } = await octokit.rest.repos.listCommentsForCommit({
     owner,
     repo,


### PR DESCRIPTION
Changes the metadata object added to the main branch comments, including historical data for the past X commits.

We're not doing anything with this data yet, but it'll allow us to render a chart on every comment showing the evolution of each metric over time.