### PR TITLE
feat: add graph for historical data

### DIFF
--- a/src/lib/comment.js
+++ b/src/lib/comment.js
@@ -49,9 +49,7 @@ const getGraph = ({ metrics, metricName, units }) => {
     }
   })
   const graph = drawGraph(points.slice(0, MAX_GRAPH_ITEMS), { fillLast: true })
-  // eslint-disable-next-line fp/no-mutating-methods
-  const legendItems = [...points]
-    .reverse()
+  const legendItems = points
     .map(
       ({ commit, displayValue, label }) =>
         `- ${label === 'T' ? '**' : ''}${label} (${label === 'T' ? 'current commit' : commit}): ${displayValue}${

--- a/src/lib/comment.js
+++ b/src/lib/comment.js
@@ -22,10 +22,12 @@ const createPullRequestComment = ({ baseSha, job, metrics, previousMetrics = {},
       // format (array of objects).
       const comparison = Array.isArray(previousMetrics) ? previousMetrics[0] : previousMetrics
       const previousValue = comparison[metric.name]
+      // eslint-disable-next-line dot-notation
+      const previousSha = comparison['__commit']
       const graphMetrics = [...previousMetrics, { __commit: baseSha, [metric.name]: metric.value }]
       const graph = getGraph({ metrics: graphMetrics, metricName: metric.name, units: metric.units })
 
-      return getMetricLine(metric, previousValue, graph)
+      return getMetricLine(metric, previousValue, previousSha, graph)
     })
     .join('\n')
   const baseShaLine = baseSha && previousMetrics.length !== 0 ? `*Comparing with ${baseSha}*\n\n` : ''
@@ -34,17 +36,28 @@ const createPullRequestComment = ({ baseSha, job, metrics, previousMetrics = {},
 }
 
 const getGraph = ({ metrics, metricName, units }) => {
-  const ASCII_A = 65
-  const points = metrics.map((metric, index) => ({
-    // eslint-disable-next-line dot-notation
-    commit: metric['__commit'],
-    displayValue: formatValue(metric[metricName], units),
-    label: String.fromCharCode(ASCII_A + index),
-    value: metric[metricName],
-  }))
+  const points = metrics.map((metric, index) => {
+    const offset = metrics.length - 1 - index
+    const label = offset === 0 ? 'T' : `T-${offset}`
+
+    return {
+      // eslint-disable-next-line dot-notation
+      commit: metric['__commit'],
+      displayValue: formatValue(metric[metricName], units),
+      label,
+      value: metric[metricName],
+    }
+  })
   const graph = drawGraph(points.slice(0, MAX_GRAPH_ITEMS), { fillLast: true })
-  const legendItems = points
-    .map(({ commit, displayValue, label }) => `- ${label}: ${commit} (${displayValue})`)
+  // eslint-disable-next-line fp/no-mutating-methods
+  const legendItems = [...points]
+    .reverse()
+    .map(
+      ({ commit, displayValue, label }) =>
+        `- ${label === 'T' ? '**' : ''}${label} (${label === 'T' ? 'current commit' : commit}): ${displayValue}${
+          label === 'T' ? '**' : ''
+        }`,
+    )
     .join('\n')
   const legend = `<details>\n<summary>Legend</summary>\n\n${legendItems}</details>`
   const lines = ['```', graph, '```', legend]
@@ -75,14 +88,14 @@ const getMetricsForHeadBranch = ({ commitSha, job, metrics, previousCommit }) =>
   return [currentCommitMetrics]
 }
 
-const getMetricLine = ({ displayName, name, units, value }, previousValue, graph) => {
-  const comparison = getMetricLineComparison(value, previousValue)
+const getMetricLine = ({ displayName, name, units, value }, previousValue, previousSha, graph) => {
+  const comparison = getMetricLineComparison(value, previousValue, previousSha)
   const formattedValue = formatValue(value, units)
 
   return `### ${displayName || name}: ${formattedValue}\n${comparison ? ` ${comparison}` : ''}\n${graph}`
 }
 
-const getMetricLineComparison = (value, previousValue) => {
+const getMetricLineComparison = (value, previousValue, previousSha) => {
   if (previousValue === undefined) {
     return ''
   }
@@ -96,8 +109,9 @@ const getMetricLineComparison = (value, previousValue) => {
   // eslint-disable-next-line no-magic-numbers
   const percentage = Math.abs((difference / value) * 100).toFixed(2)
   const [word, icon] = difference > 0 ? ['increase', '⬆️'] : ['decrease', '⬇️']
+  const shaText = previousSha ? ` vs. ${previousSha}` : ''
 
-  return `${icon} (${percentage}% ${word})`
+  return `${icon} **${percentage}% ${word}**${shaText}`
 }
 
 const findDeltaComment = (body, job) => {

--- a/src/lib/graph.js
+++ b/src/lib/graph.js
@@ -1,0 +1,88 @@
+const BAR_BODY = '|  |'
+const BAR_BODY_FILLED = '|▒▒|'
+const BAR_GAP = '    '
+const BAR_TOP = '┌──┐'
+const LINE_COUNT = 20
+
+const drawBase = (points) => {
+  const axis = points
+    .map(() => {
+      const padding = '─'.repeat(BAR_GAP.length / 2)
+
+      return `${padding}┴${'─'.repeat(BAR_BODY.length - 2)}┴${padding}`
+    })
+    .join('')
+  const legend = points
+    .map(({ label }) => {
+      const padding = ' '.repeat(BAR_GAP.length / 2)
+      const text = getPaddedString(label, BAR_BODY.length)
+
+      return `${padding}${text}${padding}`
+    })
+    .join('')
+
+  return `└${axis.slice(1)}>\n${legend}`
+}
+
+const drawGraph = (values, { fillLast = false } = {}) => {
+  const maxValue = values.reduce((max, { value }) => (value > max ? value : max), 0)
+  const increment = maxValue / LINE_COUNT
+  const augmentedValues = values.map((dataPoint) => {
+    const filledLevels = Math.round(dataPoint.value / increment)
+
+    return { ...dataPoint, emptyLevels: LINE_COUNT - filledLevels }
+  })
+
+  const levels = Array.from({ length: LINE_COUNT }, (_, index) =>
+    drawLevel({ fillLast, level: index + 1, values: augmentedValues }),
+  )
+  const topLevels = [
+    drawLevel({ level: -1, values: augmentedValues }),
+    drawLevel({ level: 0, values: augmentedValues }),
+  ]
+  const base = drawBase(values)
+
+  return `${[...topLevels, ...levels].join('\n')}\n${base}`
+}
+
+const drawLevel = ({ fillLast, level, values }) => {
+  const bars = values
+    // eslint-disable-next-line complexity
+    .map(({ displayValue, emptyLevels, value }, index) => {
+      const isLastValue = index === values.length - 1
+
+      if (emptyLevels < level) {
+        return isLastValue && fillLast ? BAR_BODY_FILLED : BAR_BODY
+      }
+
+      if (emptyLevels === level) {
+        return BAR_TOP
+      }
+
+      if (emptyLevels - 1 === level) {
+        return getPaddedString((displayValue || value).toString(), BAR_BODY.length)
+      }
+
+      return ' '.repeat(BAR_BODY.length)
+    })
+    .join(BAR_GAP)
+
+  return `${level === -1 ? '^' : '│'} ${bars}`
+}
+
+const getPaddedString = (string, length) => {
+  const totalPadding = length - string.length
+
+  if (totalPadding < 0) {
+    return `${string.slice(0, length - 1)}…`
+  }
+
+  const paddingRightLength = Math.max(0, Math.round(totalPadding / 2))
+  const paddingLeftLength = Math.max(0, totalPadding - paddingRightLength)
+  const paddingLeft = ' '.repeat(paddingLeftLength)
+  const paddingRight = ' '.repeat(paddingRightLength)
+
+  return `${paddingLeft}${string}${paddingRight}`
+}
+
+module.exports = { drawGraph }

--- a/src/lib/graph.js
+++ b/src/lib/graph.js
@@ -14,14 +14,13 @@ const drawBase = (points) => {
     .join('')
   const legend = points
     .map(({ label }) => {
-      const padding = ' '.repeat(BAR_GAP.length / 2)
       const text = getPaddedString(label, BAR_BODY.length)
 
-      return `${padding}${text}${padding}`
+      return text
     })
-    .join('')
+    .join(BAR_GAP)
 
-  return `└${axis.slice(1)}>\n${legend}`
+  return `└${axis.slice(1)}>\n  ${legend}`
 }
 
 const drawGraph = (values, { fillLast = false } = {}) => {


### PR DESCRIPTION
Adds a graph on each PR comment displaying historical data for each metric.

<img width="835" alt="Screenshot 2021-05-30 at 12 44 13" src="https://user-images.githubusercontent.com/4162329/120102891-007c9180-c145-11eb-9aea-be91fb9edbcf.png">
