### PR TITLE
fix: reduce max graph items

### DIFF
--- a/src/lib/comment.js
+++ b/src/lib/comment.js
@@ -3,7 +3,7 @@ const regexEscape = require('regex-escape')
 const { drawGraph } = require('./graph')
 const { formatValue } = require('./units')
 
-const MAX_GRAPH_ITEMS = 20
+const MAX_GRAPH_ITEMS = 16
 const PAST_METRICS_COUNT = 30
 
 const createHeadBranchComment = ({ commitSha, metrics, job, previousCommit, title }) => {


### PR DESCRIPTION
Reduces the number of items shown in the graph to fit in the default GitHub comment width without requiring horizontal scrolling.