### PR TITLE
feat: support custom PR numbers for workflow_run

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ A GitHub Action for reporting benchmark data and comparing it against a baseline
 
 ## The basics
 
-This action reads benchmark metrics on GitHub pull requests and commits, and reports them by adding a comment with any metrics found. It also compares then against the latest commit on the main branch, treating it as the baseline.
+This action reads benchmark metrics on GitHub pull requests and commits, and reports them by adding a comment with any
+metrics found. It also compares then against the latest commit on the main branch, treating it as the baseline.
 
-The action looks for benchmark data in files on the repository root. These should be named in the format `.delta.<metric name>` — e.g. `.delta.install_time` will create a metric called `install_time`.
+The action looks for benchmark data in files on the repository root. These should be named in the format
+`.delta.<metric name>` — e.g. `.delta.install_time` will create a metric called `install_time`.
 
 These files should contain:
 
@@ -17,6 +19,7 @@ These files should contain:
 - A human-friendly name of the metric (optional)
 
 _Example: `.delta.install_time`_
+
 ```
 350ms (Installation time)
 ```
@@ -29,17 +32,19 @@ The units will determine how the values will be formatted in the benchmark repor
 - Storage (formatted with [`pretty-bytes`](https://www.npmjs.com/package/pretty-bytes))
   - `b` / `bytes`
   - `kb` / `kilobytes`
-- Unitless (formatted with [`Number.prototype.toLocaleString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString))
+- Unitless (formatted with
+  [`Number.prototype.toLocaleString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString))
 
 ## Configuration
 
-The action supports the following inputs:
+The action supports the following optional inputs:
 
-| Name          | Description                              | Default              |
-| ------------- | ---------------------------------------- | -------------------- |
-| `base_branch` | Name of the base branch                  | `main`               |
-| `title`       | Title/heading to include in the comments | Delta results        |
-| `token`       | GitHub access token                      |                      |
+| Name          | Description                                             | Default       |
+| ------------- | ------------------------------------------------------- | ------------- |
+| `base_branch` | Name of the base branch, if not auto detected           | autodetect    |
+| `title`       | Title/heading to include in the comments                | Delta results |
+| `token`       | GitHub access token                                     | GITHUB_TOKEN  |
+| `pr_number`   | The PR this run is associated with (for `workflow_run`) | autodetect    |
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -4,12 +4,19 @@ inputs:
   base_branch:
     default: main
     description: 'Name of the base branch'
+    required: false
   title:
     default: Delta results
     description: 'Title used in the comments'
+    required: false
   token:
     description: 'GitHub access token'
-    required: true
+    required: false
+    default: ${{ github.token }}
+  pr_number:
+    description: 'The PR this run is associated with (for `workflow_run`)'
+    required: false
+    default: ''
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/src/lib/inputs.js
+++ b/src/lib/inputs.js
@@ -10,12 +10,9 @@ const getPrNumber = () => {
     return payload.number
   }
 
-  if (
-    eventName === 'workflow_run' &&
-    payload?.workflow_run?.event === 'pull_request' &&
-    payload?.workflow_run?.pull_requests?.length === 1
-  ) {
-    return payload.workflow_run.pull_requests[0].number
+  const prNumberInput = Number.parseInt(core.getInput('pr_number'))
+  if (Number.isInteger(prNumberInput)) {
+    return prNumberInput
   }
 }
 
@@ -23,14 +20,13 @@ export const getInputs = () => {
   const {
     GITHUB_DEV_BASE_BRANCH: envBaseBranch,
     GITHUB_REPOSITORY: repository,
-    GITHUB_TOKEN: envToken,
     GITHUB_WORKSPACE: rootPath = process.cwd(),
   } = process.env
   const { job, ref, sha: commitSha } = context
   const baseBranch = envBaseBranch || core.getInput('base_branch')
-  const title = core.getInput('title')
+  const title = core.getInput('title', { required: true })
   const [owner, repo] = repository.split('/')
-  const token = envToken || core.getInput('token')
+  const token = core.getInput('token', { required: true })
   const prNumber = getPrNumber()
 
   return {


### PR DESCRIPTION
#### Summary

This allows setting a custom PR number as input, in case the action is run on the `workflow_run` event.

This is one more step to support this action in a split workflow setup.
I'm trying to do this in cli to support PRs from external forks. The workflow is already split (https://github.com/netlify/cli/tree/main/.github/workflows), but there is no way to detect which PR the workflow was triggered from, which I tried before. So instead use an input and the workflow itself has to upload the pr number and then download it again similar to this: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
